### PR TITLE
Spencer middleware changes Resolve #3

### DIFF
--- a/docs-core/src/main/resources/config.properties
+++ b/docs-core/src/main/resources/config.properties
@@ -1,1 +1,1 @@
-db.version=28
+db.version=29

--- a/docs-core/src/main/resources/db/update/dbupdate-029-0.sql
+++ b/docs-core/src/main/resources/db/update/dbupdate-029-0.sql
@@ -1,0 +1,5 @@
+insert into T_USER(USE_ID_C, USE_IDROLE_C, USE_USERNAME_C, USE_PASSWORD_C, USE_EMAIL_C, USE_CREATEDATE_D, USE_PRIVATEKEY_C) values('spencer', 'user', 'spencer', '', 'spencer@localhost', NOW(), 'SpencerPk');
+insert into T_USER(USE_ID_C, USE_IDROLE_C, USE_USERNAME_C, USE_PASSWORD_C, USE_EMAIL_C, USE_CREATEDATE_D, USE_PRIVATEKEY_C) values('hanna', 'user', 'hanna', '', 'hanna@localhost', NOW(), 'HannaPk');
+insert into T_USER(USE_ID_C, USE_IDROLE_C, USE_USERNAME_C, USE_PASSWORD_C, USE_EMAIL_C, USE_CREATEDATE_D, USE_PRIVATEKEY_C) values('jennifer', 'user', 'jennifer', '', 'jennifer@localhost', NOW(), 'JenniferPk');
+insert into T_USER(USE_ID_C, USE_IDROLE_C, USE_USERNAME_C, USE_PASSWORD_C, USE_EMAIL_C, USE_CREATEDATE_D, USE_PRIVATEKEY_C) values('anesha', 'user', 'anesha', '', 'anesha@localhost', NOW(), 'AneshaPk');
+update T_CONFIG set CFG_VALUE_C = '29' where CFG_ID_C = 'DB_VERSION';

--- a/docs-web/src/dev/resources/config.properties
+++ b/docs-web/src/dev/resources/config.properties
@@ -1,3 +1,3 @@
 api.current_version=${project.version}
 api.min_version=1.0
-db.version=28
+db.version=29

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -19,6 +19,7 @@ import com.sismics.docs.core.model.context.AppContext;
 import com.sismics.docs.core.model.jpa.Document;
 import com.sismics.docs.core.model.jpa.File;
 import com.sismics.docs.core.model.jpa.User;
+import com.sismics.docs.core.model.jpa.DocumentReviewer;
 import com.sismics.docs.core.util.*;
 import com.sismics.docs.core.util.jpa.PaginatedList;
 import com.sismics.docs.core.util.jpa.PaginatedLists;
@@ -779,6 +780,34 @@ public class DocumentResource extends BaseResource {
         // Save the document, create the base ACLs
         document = DocumentUtil.createDocument(document, principal.getId());
 
+        // Create the document reviewer (test document reviewer based off of Spencer)
+        DocumentReviewerDao docRevDao1 = new DocumentReviewerDao();
+        DocumentReviewer docRev1 = new DocumentReviewer();
+        docRev1.setUserId("spencer");
+        docRev1.setDocumentId(document.getId());
+        String docRevId1 = docRevDao1.create(docRev1, "spencer", document.getId());
+
+        // Create the document reviewer (test document reviewer based off of Hanna)
+        DocumentReviewerDao docRevDao2 = new DocumentReviewerDao();
+        DocumentReviewer docRev2 = new DocumentReviewer();
+        docRev1.setUserId("hanna");
+        docRev1.setDocumentId(document.getId());
+        String docRevId2 = docRevDao2.create(docRev2, "hanna", document.getId());
+
+        // Create the document reviewer (test document reviewer based off of Jennifer)
+        DocumentReviewerDao docRevDao3 = new DocumentReviewerDao();
+        DocumentReviewer docRev3 = new DocumentReviewer();
+        docRev1.setUserId("jennifer");
+        docRev1.setDocumentId(document.getId());
+        String docRevId3 = docRevDao3.create(docRev3, "jennifer", document.getId());
+
+        // Create the document reviewer (test document reviewer based off of Anesha)
+        DocumentReviewerDao docRevDao4 = new DocumentReviewerDao();
+        DocumentReviewer docRev4 = new DocumentReviewer();
+        docRev1.setUserId("anesha");
+        docRev1.setDocumentId(document.getId());
+        String docRevId4 = docRevDao4.create(docRev4, "anesha", document.getId());
+
         // Update tags
         updateTagList(document.getId(), tagList);
 
@@ -798,8 +827,34 @@ public class DocumentResource extends BaseResource {
         documentCreatedAsyncEvent.setDocumentId(document.getId());
         ThreadLocalContext.get().addAsyncEvent(documentCreatedAsyncEvent);
 
+        JsonArrayBuilder reviewers = Json.createArrayBuilder();
+        reviewers.add(Json.createObjectBuilder()
+                    .add("id", docRevId1)
+                    .add("userId", "spencer")
+                    .add("documentId", document.getId())
+                    .add("score", "None"));
+
+        reviewers.add(Json.createObjectBuilder()
+                    .add("id", docRevId2)
+                    .add("userId", "hanna")
+                    .add("documentId", document.getId())
+                    .add("score", "None"));        
+        
+        reviewers.add(Json.createObjectBuilder()
+                    .add("id", docRevId3)
+                    .add("userId", "jennifer")
+                    .add("documentId", document.getId())
+                    .add("score", "None"));
+        
+        reviewers.add(Json.createObjectBuilder()
+                    .add("id", docRevId4)
+                    .add("userId", "anesha")
+                    .add("documentId", document.getId())
+                    .add("score", "None"));
+
         JsonObjectBuilder response = Json.createObjectBuilder()
-                .add("id", document.getId());
+                .add("id", document.getId())
+                .add("reviewers", reviewers);
         return Response.ok().entity(response.build()).build();
     }
     

--- a/docs-web/src/prod/resources/config.properties
+++ b/docs-web/src/prod/resources/config.properties
@@ -1,3 +1,3 @@
 api.current_version=${project.version}
 api.min_version=1.0
-db.version=28
+db.version=29

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestDocumentResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestDocumentResource.java
@@ -81,6 +81,12 @@ public class TestDocumentResource extends BaseJerseyTest {
                         .param("create_date", Long.toString(create1Date))), JsonObject.class);
         String document1Id = json.getString("id");
         Assert.assertNotNull(document1Id);
+
+        // See if Document Reviewers for document 1 exists
+        JsonArray reviewers = json.getJsonArray("reviewers");
+        Assert.assertEquals(4, reviewers.size());
+        Assert.assertEquals("spencer", reviewers.getJsonObject(0).getString("userId"));
+        Assert.assertEquals(document1Id, reviewers.getJsonObject(1).getString("documentId"));
         
         // Create a document with document1
         json = target().path("/document").request()


### PR DESCRIPTION
In order to associate documents with document reviewers, I had to ensure that document reviewers were linked with newly created documents. As mentions in the issue comments, I created 4 dummy test document reviewers and made every document reviewer linked with them. I also ensured that this change was noted in the API, by manipulating the JSON object for documents and adding an extra key value pair, where the key is reviewers and the value is an array of document reviewers. I tested this in the testdocumentresource.java file. I did this by first creating a document and then checking the existence of the document reviewer objects.